### PR TITLE
Fix resource leak by using Unix.close_process_in instead of close_in

### DIFF
--- a/config.ml
+++ b/config.ml
@@ -44,12 +44,12 @@ let get_command_output cmd =
 let ic = Unix.open_process_in cmd in
 try
   let output = input_line ic in
-  close_in ic;
+  let _ = Unix.close_process_in ic in
   if String.trim output = "" then "N/A" else output
-with End_of_file -> (
-  close_in ic;
+with 
+| End_of_file ->
+  let _ = Unix.close_process_in ic in
   "N/A"
-)
 
 let rec prompt_input prompt validate error_message =
 print_string (cyan "→ " ^ bold prompt ^ ": ");


### PR DESCRIPTION
### Fixed Resource Leak in `get_command_output`

The original code used `close_in` to close a process opened by `Unix.open_process_in`, which is incorrect and can lead to resource leaks. This PR fixes the issue by using `Unix.close_process_in` to properly close the process.

#### Changes:
- Replaced `close_in ic` with `Unix.close_process_in ic`.
- Ensured proper process termination even in case of exceptions.

#### Impact:
- Prevents resource leaks.
- Ensures correct process management.